### PR TITLE
Generate report even if exited with `sys.exit()`

### DIFF
--- a/behave_html_pretty_formatter/html_pretty.py
+++ b/behave_html_pretty_formatter/html_pretty.py
@@ -5,6 +5,7 @@ Inspired by https://github.com/Hargne/jest-html-reporter
 
 from __future__ import absolute_import
 
+import atexit
 import base64
 import os
 import time
@@ -921,6 +922,8 @@ class PrettyHTMLFormatter(Formatter):
 
         self.suite_start_time = datetime.now()
 
+        self._closed = False
+
         # Some type of icon can be set.
         self.icon = None
 
@@ -961,6 +964,8 @@ class PrettyHTMLFormatter(Formatter):
             if key.startswith(additional_info_path):
                 short_key = key.replace(additional_info_path, "")
                 self.additional_info[short_key] = item
+
+        atexit.register(self.close)
 
     def _str_to_bool(self, value):
         assert value.lower() in ["true", "false", "yes", "no", "0", "1"]
@@ -1103,6 +1108,9 @@ class PrettyHTMLFormatter(Formatter):
         """
         Generates the entire html page with dominate.
         """
+        if self._closed:
+            return
+        self._closed = True
         # Set finish time of the last feature.
         current_feature = self.current_feature
         if current_feature:

--- a/behave_html_pretty_formatter/html_pretty.py
+++ b/behave_html_pretty_formatter/html_pretty.py
@@ -169,6 +169,10 @@ class Feature:
         """
         Converts this object to HTML.
         """
+        # Create unexecuted scenario, if there are unprocessed embeds.
+        if self.to_embed:
+            self._add_unexecuted_scenario()
+
         # Feature Title.
         with div(cls="feature-title flex-gap"):
             # Generate icon if present.
@@ -269,6 +273,24 @@ class Feature:
         with div(cls="feature-container", id=f"f{self.counter}"):
             for scenario in self.scenarios:
                 scenario.generate_scenario(formatter)
+
+    def _add_unexecuted_scenario(self):
+        class DummyScenario:  # pylint: disable=too-few-public-methods
+            """
+            Dummy scenario setting minimal attributes setting minimum attributes,
+            so formatter would not crash.
+            """
+
+            name = "Unknown scenario"
+            effective_tags = []
+            description = ""
+            location = None
+            steps = []
+            error_message = "Embedding done before scenario executed"
+            exception = None
+            exc_traceback = None
+
+        self.add_scenario(DummyScenario(), self.counter, pseudo_steps=True)
 
 
 class Scenario:

--- a/behave_html_pretty_formatter/html_pretty.py
+++ b/behave_html_pretty_formatter/html_pretty.py
@@ -289,10 +289,9 @@ class Feature:
             error_message = None
             exception = None
             exc_traceback = None
-
             status = Status.failed.name
-            self.before_scenario_status = Status.failed.name
 
+        self.before_scenario_status = Status.failed.name
         self.add_scenario(DummyScenario(), self.counter, pseudo_steps=True)
 
 

--- a/behave_html_pretty_formatter/html_pretty.py
+++ b/behave_html_pretty_formatter/html_pretty.py
@@ -286,9 +286,12 @@ class Feature:
             description = ""
             location = None
             steps = []
-            error_message = "Embedding done before scenario executed"
+            error_message = None
             exception = None
             exc_traceback = None
+
+            status = Status.failed.name
+            self.before_scenario_status = Status.failed.name
 
         self.add_scenario(DummyScenario(), self.counter, pseudo_steps=True)
 
@@ -317,7 +320,12 @@ class Scenario:
         self.tags = [Tag(tag) for tag in scenario.effective_tags]
 
         self.location = scenario.location
-        self.status = Status.skipped.name
+
+        if self._scenario.status:
+            self.status = self._scenario.status
+        else:
+            self.status = Status.skipped.name
+
         self.duration = 0.0
         self.match_id = -1
         self.steps_finished = False
@@ -329,6 +337,7 @@ class Scenario:
 
         self.saved_matched_filename = None
         self.saved_matched_line = None
+
         # Process before_scenario errors.
         self.report_error(scenario)
 


### PR DESCRIPTION
During the scenario run, formatter only caches the data, that re being compiled to HTML at the end, in `close()` function. This is unfortunate, if code exits with `sys.exit()` the report is empty. Fix this with registering `atexit` hook, which will call `close()` on exit. Make sure, `close()` is executed at most one, otherwise report is doubled.

Closes #34