### PR TITLE
Fix error message not being embedded if step is Status.error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+behave-html-pretty-formatter 1.15.1
+===================================
+Fix not embedding error message if step is Status.error.
+
+
 behave-html-pretty-formatter 1.15
 =================================
 Fix behave version to 1.3.0.

--- a/behave_html_pretty_formatter/html_pretty.py
+++ b/behave_html_pretty_formatter/html_pretty.py
@@ -503,22 +503,26 @@ class Scenario:
         """
         Embeds error message and traceback.
         """
-        if not behave_obj.error_message:
+
+        err = behave_obj.error_message
+        if not err:
+            err = behave_obj.exception
+        if not err:
             return
         if self.reported_error:
-            if self.reported_error.data == behave_obj.error_message:
+            if self.reported_error.data == err:
                 return
-            if self.reported_error.data in behave_obj.error_message:
+            if self.reported_error.data in err:
                 # Do not update traceback, as behave saves only first traceback.
                 self.reported_error.set_data(
                     "text",
-                    behave_obj.error_message,
+                    err,
                     "Error Message",
                 )
                 return
-        self.reported_error = Embed("text", behave_obj.error_message, "Error Message")
+        self.reported_error = Embed("text", err, "Error Message")
         self.embed(self.reported_error)
-        if "Traceback" not in behave_obj.error_message:
+        if "Traceback" not in err:
             self.embed(
                 Embed(
                     "text",
@@ -634,8 +638,11 @@ class Step:
         if hasattr(Status, "hook_error") and self.status is Status.hook_error:
             self.status = Status.failed
 
+        if hasattr(Status, "error") and self.status is Status.error:
+            self.status = Status.failed
+
         # If the step has error message and step failed, set the error message.
-        if result.error_message and self.status is Status.failed:
+        if (result.error_message or result.exception) and self.status is Status.failed:
             self.scenario.report_error(result)
 
         # If the step is undefined use the behave function to provide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "behave-html-pretty-formatter"
-version = "1.15"
+version = "1.15.1"
 description = "Pretty HTML Formatter for Behave"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
This deserves better rewrite. We should not check `status == Status.failed` but rather `status in failed_statuses` or `status not in success_statuses`. But that is for another rewrite, hotfixing by replacing error to failed for now.